### PR TITLE
Backend refactor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+-	Renamed apiKey to apikey
 -	Renamed fields to consistent casing of ID
 -	Renamed category shortdesc and longdesc to name and description
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 -	Renamed fields to consistent casing of ID
+-	Renamed category shortdesc and longdesc to name and description
 
 ## [1.28.1] - [2022-01-24]
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+-	Renamed fields to consistent casing of ID
+
 ## [1.28.1] - [2022-01-24]
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "fagc-api-wrapper",
-	"version": "1.27.6",
+	"version": "1.28.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "fagc-api-wrapper",
-			"version": "1.27.6",
+			"version": "1.28.1",
 			"license": "MIT",
 			"dependencies": {
 				"@discordjs/collection": "^0.1.6",
 				"cross-fetch": "^3.1.4",
 				"discord-api-types": "^0.23.1",
-				"fagc-api-types": "^1.9.0",
+				"fagc-api-types": "^1.10.0",
 				"faker": "^5.5.3",
 				"isomorphic-ws": "^4.0.1",
 				"jest-fetch-mock": "^3.0.3",
@@ -2555,9 +2555,9 @@
 			}
 		},
 		"node_modules/fagc-api-types": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/fagc-api-types/-/fagc-api-types-1.9.0.tgz",
-			"integrity": "sha512-7BzTEIG9k7ahNvujlCB5zEtosmTXecDpv9UjAnrI+atDFwDVxr9dzDFXHqHoWBO8v3KAeTSpAUgHy+1V4Cx5hw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/fagc-api-types/-/fagc-api-types-1.10.0.tgz",
+			"integrity": "sha512-sS8hrQY1oBLQZ6cgB5068X/8ZlrqJNM6kI3j7SIUHbKvekxYpIH/1t41pjyEw4Q/IpDmEbNl+xKH6dCCYrnyHg==",
 			"dependencies": {
 				"discord-api-types": "^0.23.1",
 				"zod": "^3.11.6"
@@ -7360,9 +7360,9 @@
 			}
 		},
 		"fagc-api-types": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/fagc-api-types/-/fagc-api-types-1.9.0.tgz",
-			"integrity": "sha512-7BzTEIG9k7ahNvujlCB5zEtosmTXecDpv9UjAnrI+atDFwDVxr9dzDFXHqHoWBO8v3KAeTSpAUgHy+1V4Cx5hw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/fagc-api-types/-/fagc-api-types-1.10.0.tgz",
+			"integrity": "sha512-sS8hrQY1oBLQZ6cgB5068X/8ZlrqJNM6kI3j7SIUHbKvekxYpIH/1t41pjyEw4Q/IpDmEbNl+xKH6dCCYrnyHg==",
 			"requires": {
 				"discord-api-types": "^0.23.1",
 				"zod": "^3.11.6"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@discordjs/collection": "^0.1.6",
 		"cross-fetch": "^3.1.4",
 		"discord-api-types": "^0.23.1",
-		"fagc-api-types": "^1.9.0",
+		"fagc-api-types": "^1.10.0",
 		"faker": "^5.5.3",
 		"isomorphic-ws": "^4.0.1",
 		"jest-fetch-mock": "^3.0.3",

--- a/src/managers/BaseManager.ts
+++ b/src/managers/BaseManager.ts
@@ -66,7 +66,7 @@ export default class BaseManager<HoldsWithId extends Common> {
 		this.fetchingCache.clear()
 	}
 
-	resolveID(id: Common["id"]): HoldsWithId | null {
+	resolveId(id: Common["id"]): HoldsWithId | null {
 		const cached = this.cache.get(id)
 		if (cached) return cached
 		return null

--- a/src/managers/CategoryManager.ts
+++ b/src/managers/CategoryManager.ts
@@ -97,11 +97,11 @@ export class CategoryManager extends BaseManager<Category> {
 
 	async modify({
 		categoryId,
-		shortdesc, longdesc,
+		name, description,
 		reqConfig = {}
 	}: {
 		categoryId: string,
-		shortdesc?: string, longdesc?: string
+		name?: string, description?: string
 	} & FetchRequestTypes): Promise<Category | null> {
 		const req = await fetch(
 			`${this.apiurl}/categories/${strictUriEncode(categoryId)}`,
@@ -109,8 +109,8 @@ export class CategoryManager extends BaseManager<Category> {
 				method: "PATCH",
 				credentials: "include",
 				body: JSON.stringify({
-					shortdesc: shortdesc,
-					longdesc: longdesc
+					name: name,
+					description: description
 				}),
 				headers: {
 					authorization: masterAuthenticate(this, reqConfig),

--- a/src/managers/CategoryManager.ts
+++ b/src/managers/CategoryManager.ts
@@ -53,15 +53,15 @@ export class CategoryManager extends BaseManager<Category> {
 	}
 
 	async fetchCategory({
-		categoryid,
+		categoryId,
 		cache = true,
 		force = false
 	}: {
-		categoryid: string
+		categoryId: string
 	} & FetchRequestTypes): Promise<Category | null> {
 		if (!force) {
 			const cached =
-				this.cache.get(categoryid) || this.fetchingCache.get(categoryid)
+				this.cache.get(categoryId) || this.fetchingCache.get(categoryId)
 			if (cached) return cached
 		}
 		let promiseResolve!: (value: Category | PromiseLike<Category | null> | null) => void
@@ -69,10 +69,10 @@ export class CategoryManager extends BaseManager<Category> {
 			promiseResolve = resolve
 		})
 
-		if (cache) this.fetchingCache.set(categoryid, fetchingPromise)
+		if (cache) this.fetchingCache.set(categoryId, fetchingPromise)
 
 		const req = await fetch(
-			`${this.apiurl}/categories/${strictUriEncode(categoryid)}`,
+			`${this.apiurl}/categories/${strictUriEncode(categoryId)}`,
 			{
 				credentials: "include",
 			}
@@ -82,7 +82,7 @@ export class CategoryManager extends BaseManager<Category> {
 		const parsed = Category.nullable().safeParse(fetched)
 		if (!parsed.success || parsed.data === null) {
 			promiseResolve(null)
-			setTimeout(() => this.fetchingCache.delete(categoryid), 0)
+			setTimeout(() => this.fetchingCache.delete(categoryId), 0)
 			if (!parsed.success) throw parsed.error
 			return null
 		}
@@ -90,7 +90,7 @@ export class CategoryManager extends BaseManager<Category> {
 		if (cache) this.add(parsed.data)
 		promiseResolve(fetched)
 		setTimeout(() => {
-			this.fetchingCache.delete(categoryid)
+			this.fetchingCache.delete(categoryId)
 		}, 0)
 		return parsed.data
 	}

--- a/src/managers/CommunityManager.ts
+++ b/src/managers/CommunityManager.ts
@@ -256,9 +256,9 @@ export default class CommunityManager extends BaseManager<Community> {
 
 		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
 		const parsed = z.object({
-			apiKey: z.string(),
+			apikey: z.string(),
 		}).parse(key)
-		return parsed.apiKey
+		return parsed.apikey
 	}
 	
 	/**
@@ -283,9 +283,9 @@ export default class CommunityManager extends BaseManager<Community> {
 
 		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
 		const parsed = z.object({
-			apiKey: z.string(),
+			apikey: z.string(),
 		}).parse(key)
-		return parsed.apiKey
+		return parsed.apikey
 	}
 
 	/**
@@ -314,9 +314,9 @@ export default class CommunityManager extends BaseManager<Community> {
 
 		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
 		const parsed = z.object({
-			apiKey: z.string(),
+			apikey: z.string(),
 		}).parse(key)
-		return parsed.apiKey
+		return parsed.apikey
 	}
 
 	/**
@@ -343,9 +343,9 @@ export default class CommunityManager extends BaseManager<Community> {
 
 		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
 		const parsed = z.object({
-			apiKey: z.string(),
+			apikey: z.string(),
 		}).parse(key)
-		return parsed.apiKey
+		return parsed.apikey
 	}
 
 	async create({
@@ -358,7 +358,7 @@ export default class CommunityManager extends BaseManager<Community> {
 		contact: string,
 	} & FetchRequestTypes): Promise<{
 		community: Community
-		apiKey: string
+		apikey: string
 	}> {
 		const req = await fetch(`${this.apiurl}/communities`, {
 			method: "POST",
@@ -379,7 +379,7 @@ export default class CommunityManager extends BaseManager<Community> {
 		
 		const parsedCreate = z.object({
 			community: Community,
-			apiKey: z.string(),
+			apikey: z.string(),
 		}).parse(create)
 		if (cache) this.add(parsedCreate.community)
 		return parsedCreate

--- a/src/managers/CommunityManager.ts
+++ b/src/managers/CommunityManager.ts
@@ -1,4 +1,5 @@
 import "cross-fetch/polyfill"
+import { strict as assert } from "assert"
 import { ManagerOptions, WrapperOptions, GenericAPIError, AuthError } from "../types"
 import BaseManager from "./BaseManager"
 import strictUriEncode from "strict-uri-encode"
@@ -44,7 +45,7 @@ export default class CommunityManager extends BaseManager<Community> {
 		config: SetCommunityConfig,
 	} & FetchRequestTypes): Promise<Community> {
 		const req = await fetch(
-			`${this.apiurl}/communities`,
+			`${this.apiurl}/communities/own`,
 			{
 				method: "PATCH",
 				body: JSON.stringify(config),
@@ -163,7 +164,7 @@ export default class CommunityManager extends BaseManager<Community> {
 	}: {
 		config: SetGuildConfig,
 	} & FetchRequestTypes): Promise<GuildConfig> {
-		const req = await fetch(`${this.apiurl}/communities/guilds/${config.guildId}`, {
+		const req = await fetch(`${this.apiurl}/discord/guilds/${config.guildId}`, {
 			method: "PATCH",
 			body: JSON.stringify(config),
 			credentials: "include",
@@ -186,7 +187,7 @@ export default class CommunityManager extends BaseManager<Community> {
 	}: {
 		config: SetGuildConfig,
 	} & FetchRequestTypes): Promise<GuildConfig> {
-		const req = await fetch(`${this.apiurl}/communities/guilds/${config.guildId}`, {
+		const req = await fetch(`${this.apiurl}/discord/guilds/${config.guildId}`, {
 			method: "PATCH",
 			body: JSON.stringify(config),
 			credentials: "include",
@@ -207,7 +208,7 @@ export default class CommunityManager extends BaseManager<Community> {
 		guildId,
 	}: {guildId: string} & FetchRequestTypes): Promise<GuildConfig | null> {
 		const config = await fetch(
-			`${this.apiurl}/communities/guilds/${strictUriEncode(guildId)}`,
+			`${this.apiurl}/discord/guilds/${strictUriEncode(guildId)}`,
 			{
 				credentials: "include",
 			}
@@ -222,7 +223,7 @@ export default class CommunityManager extends BaseManager<Community> {
 		reqConfig = {}
 	}: {guildId: string} & FetchRequestTypes): Promise<GuildConfig | null> {
 		const req = await fetch(
-			`${this.apiurl}/communities/guilds/${strictUriEncode(guildId)}`,
+			`${this.apiurl}/discord/guilds/${strictUriEncode(guildId)}`,
 			{
 				credentials: "include",
 				headers: {
@@ -239,43 +240,86 @@ export default class CommunityManager extends BaseManager<Community> {
 	}
 
 	/**
+	 * Manage API key for your community
+	 */
+	async manageApikey({
+		create,
+		invalidate,
+		reqConfig = {},
+	}: {
+		create?: boolean,
+		invalidate?: boolean,
+	} & FetchRequestTypes): Promise<{ apikey?: string }> {
+		const req = await fetch(`${this.apiurl}/communites/own/apikey`, {
+			method: "POST",
+			body: JSON.stringify({
+				create,
+				invalidate,
+			}),
+			credentials: "include",
+			headers: {
+				authorization: authenticate(this, reqConfig),
+				"content-type": "application/json",
+			},
+		})
+		if (req.status === 401) throw new AuthError()
+		const key = await req.json()
+
+		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
+		const parsed = z.object({
+			apikey: z.string().optional(),
+		}).parse(key)
+		return parsed
+	}
+	/**
 	 * Create a new API key for your community
 	 */
 	async createApikey({
 		reqConfig = {}
 	}: FetchRequestTypes): Promise<string> {
-		const req = await fetch(`${this.apiurl}/apikeys`, {
-			method: "POST",
-			credentials: "include",
-			headers: {
-				authorization: authenticate(this, reqConfig),
-			},
-		})
-		if (req.status === 401) throw new AuthError()
-		const key = await req.json()
-
-		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
-		const parsed = z.object({
-			apikey: z.string(),
-		}).parse(key)
-		return parsed.apikey
+		const result = await this.manageApikey({ create: true, reqConfig })
+		assert(result.apikey)
+		return result.apikey
 	}
-	
+
 	/**
-	 * Revoke API keys created until a specific timestamp
-	 * @returns New API key in case you revoke all of your keys by accident
+	 * Revoke all currently valid API keys created
+	 * @returns New API key to use
 	 */
 	async revokeApikeys({
-		invalidateUntil,
+		reqConfig = {}
+	}:  FetchRequestTypes): Promise<string> {
+		const result = await this.manageApikey({ create: true, invalidate: true, reqConfig })
+		assert(result.apikey)
+		return result.apikey
+	}
+
+	/**
+	 * Manage an API key for a community with the use of the master API
+	 */
+	async masterManageApikey({
+		communityId,
+		create,
+		keyType = "private",
+		invalidate,
 		reqConfig = {}
 	}: {
-		invalidateUntil: Date
-	} & FetchRequestTypes): Promise<string> {
-		const req = await fetch(`${this.apiurl}/apikey/revoke/${strictUriEncode(invalidateUntil.toISOString())}`, {
+		communityId: string,
+		create?: boolean,
+		keyType?: "master" | "private"
+		invalidate?: boolean,
+	} & FetchRequestTypes): Promise<{ apikey?: string }> {
+		const req = await fetch(`${this.apiurl}/communities/${strictUriEncode(communityId)}/apikey`, {
 			method: "POST",
+			body: JSON.stringify({
+				create,
+				...(create ? { type: keyType } : {}),
+				invalidate,
+			}),
 			credentials: "include",
 			headers: {
-				authorization: authenticate(this, reqConfig),
+				authorization: masterAuthenticate(this, reqConfig),
+				"content-type": "application/json",
 			},
 		})
 		if (req.status === 401) throw new AuthError()
@@ -283,10 +327,11 @@ export default class CommunityManager extends BaseManager<Community> {
 
 		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
 		const parsed = z.object({
-			apikey: z.string(),
+			apikey: z.string().optional(),
 		}).parse(key)
-		return parsed.apikey
+		return parsed
 	}
+
 
 	/**
 	 * Create an API key for a community with the use of the master API
@@ -299,53 +344,24 @@ export default class CommunityManager extends BaseManager<Community> {
 		communityId: string,
 		keyType: "master" | "private"
 	} & FetchRequestTypes): Promise<string> {
-		const params = new URLSearchParams({
-			type: keyType
-		})
-		const req = await fetch(`${this.apiurl}/communities/apikey/create/${strictUriEncode(communityId)}?${params.toString()}`, {
-			method: "POST",
-			credentials: "include",
-			headers: {
-				authorization: masterAuthenticate(this, reqConfig),
-			},
-		})
-		if (req.status === 401) throw new AuthError()
-		const key = await req.json()
-
-		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
-		const parsed = z.object({
-			apikey: z.string(),
-		}).parse(key)
-		return parsed.apikey
+		const result = await this.masterManageApikey({ communityId, create: true, keyType, reqConfig })
+		assert(result.apikey)
+		return result.apikey
 	}
 
 	/**
-	 * Revoke API keys created until a specific timestamp with the use of the master API
-	 * @returns New API key in case you revoke all of the keys by accident
+	 * Revoke all currently valid API keys created for community
+	 * @returns New API key to use
 	 */
 	async masterRevokeKeys({
 		communityId,
-		invalidateUntil,
 		reqConfig = {}
 	}: {
 		communityId: string
-		invalidateUntil: Date,
 	} & FetchRequestTypes): Promise<string> {
-		const req = await fetch(`${this.apiurl}/communities/apikey/revoke/${invalidateUntil.toISOString()}/${strictUriEncode(communityId)}`, {
-			method: "POST",
-			credentials: "include",
-			headers: {
-				authorization: masterAuthenticate(this, reqConfig),
-			},
-		})
-		if (req.status === 401) throw new AuthError()
-		const key = await req.json()
-
-		if (key.error) throw new GenericAPIError(`${key.error}: ${key.message}`)
-		const parsed = z.object({
-			apikey: z.string(),
-		}).parse(key)
-		return parsed.apikey
+		const result = await this.masterManageApikey({ communityId, create: true, invalidate: true, reqConfig })
+		assert(result.apikey)
+		return result.apikey
 	}
 
 	async create({
@@ -391,7 +407,7 @@ export default class CommunityManager extends BaseManager<Community> {
 	}: {
 		guildId: string
 	} & FetchRequestTypes): Promise<GuildConfig> {
-		const req = await fetch(`${this.apiurl}/communities/guilds`, {
+		const req = await fetch(`${this.apiurl}/discord/guilds`, {
 			method: "POST",
 			body: JSON.stringify({
 				guildId: guildId,
@@ -417,8 +433,7 @@ export default class CommunityManager extends BaseManager<Community> {
 		guildId: string,
 	} & FetchRequestTypes): Promise<void> {
 		const req = await fetch(
-			`${this.apiurl
-			}/communities/notifyGuildConfigChanged/${strictUriEncode(guildId)}`,
+			`${this.apiurl}/discord/guilds/${strictUriEncode(guildId)}/notifyChanged`,
 			{
 				method: "POST",
 				credentials: "include",
@@ -440,9 +455,9 @@ export default class CommunityManager extends BaseManager<Community> {
 		guildId: string,
 	} & FetchRequestTypes): Promise<void> {
 		const req = await fetch(
-			`${this.apiurl}/communities/guildLeave/${strictUriEncode(guildId)}`,
+			`${this.apiurl}/discord/guilds/${strictUriEncode(guildId)}`,
 			{
-				method: "POST",
+				method: "DELETE",
 				credentials: "include",
 				headers: {
 					authorization: masterAuthenticate(this, reqConfig),

--- a/src/managers/InfoManager.ts
+++ b/src/managers/InfoManager.ts
@@ -34,16 +34,16 @@ export default class InfoManager extends BaseManager<Webhook> {
 		return Webhook.parse(add)
 	}
 	async removeWebhook({
-		webhookid, webhooktoken
+		webhookId, webhookToken
 	}: {
-		webhookid: string,
-		webhooktoken: string
+		webhookId: string,
+		webhookToken: string
 	}): Promise<Webhook | null> {
 		const add = await fetch(`${this.apiurl}/informatics/webhook`, {
 			method: "DELETE",
 			body: JSON.stringify({
-				id: webhookid,
-				token: webhooktoken,
+				id: webhookId,
+				token: webhookToken,
 			}),
 			credentials: "include",
 			headers: { "content-type": "application/json" },

--- a/src/managers/InfoManager.ts
+++ b/src/managers/InfoManager.ts
@@ -21,14 +21,10 @@ export default class InfoManager extends BaseManager<Webhook> {
 		webhookId: string,
 		webhookToken: string
 	}): Promise<Webhook> {
-		const add = await fetch(`${this.apiurl}/informatics/webhook`, {
-			method: "POST",
-			body: JSON.stringify({
-				id: webhookId,
-				token: webhookToken,
-			}),
+		const webhookPath = `${strictUriEncode(webhookId)}/${strictUriEncode(webhookToken)}`
+		const add = await fetch(`${this.apiurl}/discord/webhook/${webhookPath}`, {
+			method: "PUT",
 			credentials: "include",
-			headers: { "content-type": "application/json" },
 		}).then((w) => w.json())
 		if (add.error) throw new GenericAPIError(`${add.error}: ${add.message}`)
 		return Webhook.parse(add)
@@ -39,32 +35,31 @@ export default class InfoManager extends BaseManager<Webhook> {
 		webhookId: string,
 		webhookToken: string
 	}): Promise<Webhook | null> {
-		const add = await fetch(`${this.apiurl}/informatics/webhook`, {
+		const webhookPath = `${strictUriEncode(webhookId)}/${strictUriEncode(webhookToken)}`
+		const add = await fetch(`${this.apiurl}/discord/webhook/${webhookPath}`, {
 			method: "DELETE",
-			body: JSON.stringify({
-				id: webhookId,
-				token: webhookToken,
-			}),
 			credentials: "include",
-			headers: { "content-type": "application/json" },
 		}).then((w) => w.json())
 		return Webhook.nullable().parse(add)
 	}
 
-	async notifyGuildText({
+	async messageGuild({
 		guildId,
-		text,
-		reqConfig = {}
+		content,
+		embeds,
+		reqConfig = {},
 	}: {
 		guildId: string,
-		text: string,
+		content?: string,
+		embeds?: APIEmbed[],
 	} & FetchRequestTypes): Promise<void> {
 		await fetch(
-			`${this.apiurl}/informatics/notify/${strictUriEncode(guildId)}`,
+			`${this.apiurl}/discord/guilds/${strictUriEncode(guildId)}/message`,
 			{
 				method: "POST",
 				body: JSON.stringify({
-					data: text,
+					content: content,
+					embeds: embeds,
 				}),
 				credentials: "include",
 				headers: {
@@ -75,6 +70,17 @@ export default class InfoManager extends BaseManager<Webhook> {
 		)
 	}
 
+	async notifyGuildText({
+		guildId,
+		text,
+		reqConfig = {}
+	}: {
+		guildId: string,
+		text: string,
+	} & FetchRequestTypes): Promise<void> {
+		return await this.messageGuild({ guildId, content: text, reqConfig })
+	}
+
 	async notifyGuildEmbed({
 		guildId,
 		embed,
@@ -83,19 +89,6 @@ export default class InfoManager extends BaseManager<Webhook> {
 		guildId: string,
 		embed: APIEmbed,
 	} & FetchRequestTypes): Promise<void> {
-		await fetch(
-			`${this.apiurl}/informatics/notify/${strictUriEncode(
-				guildId
-			)}/embed`,
-			{
-				method: "POST",
-				body: JSON.stringify(embed),
-				credentials: "include",
-				headers: {
-					authorization: masterAuthenticate(this, reqConfig),
-					"content-type": "application/json",
-				},
-			}
-		)
+		return await this.messageGuild({ guildId, embeds: [ embed ], reqConfig })
 	}
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -28,4 +28,4 @@ export interface WrapperOptions extends BaseWrapperOptions {
 export interface AddOptions {
 	id?: never
 }
-export type ApiID = string
+export type ApiId = string

--- a/test/categories.spec.ts
+++ b/test/categories.spec.ts
@@ -31,7 +31,7 @@ describe("Categories", () => {
 			const categories = await wrapper.categories.fetchAll({})
 
 			categories.map((category) => {
-				const resolved = wrapper.categories.resolveID(category.id)
+				const resolved = wrapper.categories.resolveId(category.id)
 				expect(resolved).toEqual(category)
 			})
 		})
@@ -64,7 +64,7 @@ describe("Categories", () => {
 				}
 			})
 			
-			const resolved = wrapper.categories.resolveID(category.id)
+			const resolved = wrapper.categories.resolveId(category.id)
 			expect(resolved).toEqual(category)
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
@@ -82,23 +82,23 @@ describe("Categories", () => {
 		it("Should fetch a single category correctly", async () => {
 			fetchMock.mockOnce(JSON.stringify(testCategories[0]))
 			const originalCategory = testCategories[0]
-			const category = await wrapper.categories.fetchCategory({ categoryid: originalCategory.id })
+			const category = await wrapper.categories.fetchCategory({ categoryId: originalCategory.id })
 			expect(category).not.toBeNull()
 			expect(category).toEqual(originalCategory)
 		})
 		it("Should cache a category after fetching it", async () => {
 			fetchMock.mockOnce(JSON.stringify(testCategories[0]))
-			const category = await wrapper.categories.fetchCategory({ categoryid: testCategories[0].id })
+			const category = await wrapper.categories.fetchCategory({ categoryId: testCategories[0].id })
 
 			expect(category).not.toBeNull()
-			const resolved = wrapper.categories.resolveID(category!.id)
+			const resolved = wrapper.categories.resolveId(category!.id)
 			expect(resolved).not.toBeNull()
 
 			expect(resolved).toEqual(category)
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
-			await expect(wrapper.categories.fetchCategory({ categoryid: testCategories[0].id })).rejects.toThrow()
+			await expect(wrapper.categories.fetchCategory({ categoryId: testCategories[0].id })).rejects.toThrow()
 		})
 	})
 
@@ -124,7 +124,7 @@ describe("Categories", () => {
 			const testCategory = testCategories[0]
 			wrapper.categories.cache.set(testCategory.id, testCategory) // set it in the cache
 			
-			const oldCached = wrapper.categories.resolveID(testCategory.id)
+			const oldCached = wrapper.categories.resolveId(testCategory.id)
 
 			const newCategory = {
 				id: testCategory.id,
@@ -140,7 +140,7 @@ describe("Categories", () => {
 
 			expect(returned).not.toBeNull()
 
-			const newCached = wrapper.categories.resolveID(testCategory.id)
+			const newCached = wrapper.categories.resolveId(testCategory.id)
 
 			// check if the returned category is correct
 			expect(returned).toEqual(newCategory)
@@ -179,7 +179,7 @@ describe("Categories", () => {
 			fetchMock.mockOnce(JSON.stringify(testCategory))
 			const returned = await wrapper.categories.remove({ categoryId: testCategory.id })
 			expect(returned).toEqual(testCategory)
-			const resolved = wrapper.categories.resolveID(testCategory.id)
+			const resolved = wrapper.categories.resolveId(testCategory.id)
 			expect(resolved).toBeNull()
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
@@ -213,8 +213,8 @@ describe("Categories", () => {
 			})
 			expect(returned).toEqual(categoryOne)
 
-			expect(wrapper.categories.resolveID(categoryOne.id)).toEqual(categoryOne)
-			expect(wrapper.categories.resolveID(categoryTwo.id)).toBeNull()
+			expect(wrapper.categories.resolveId(categoryOne.id)).toEqual(categoryOne)
+			expect(wrapper.categories.resolveId(categoryTwo.id)).toBeNull()
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			const [ categoryOne, categoryTwo ] = testCategories

--- a/test/categories.spec.ts
+++ b/test/categories.spec.ts
@@ -47,8 +47,8 @@ describe("Categories", () => {
 			fetchMock.mockOnce(JSON.stringify(testCategory))
 			const category = await wrapper.categories.create({
 				category: {
-					shortdesc: testCategory.shortdesc,
-					longdesc: testCategory.longdesc,
+					name: testCategory.name,
+					description: testCategory.description,
 				}
 			})
 
@@ -59,8 +59,8 @@ describe("Categories", () => {
 			fetchMock.mockOnce(JSON.stringify(testCategory))
 			const category = await wrapper.categories.create({
 				category: {
-					shortdesc: testCategory.shortdesc,
-					longdesc: testCategory.longdesc,
+					name: testCategory.name,
+					description: testCategory.description,
 				}
 			})
 			
@@ -71,8 +71,8 @@ describe("Categories", () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
 			await expect(wrapper.categories.create({
 				category: {
-					shortdesc: "test",
-					longdesc: "test",
+					name: "test",
+					description: "test",
 				}
 			})).rejects.toThrow()
 		})
@@ -108,14 +108,14 @@ describe("Categories", () => {
 
 			const newCategory = {
 				id: testCategory.id,
-				shortdesc: testCategory.shortdesc + "test",
-				longdesc: testCategory.longdesc + "test",
+				name: testCategory.name + "test",
+				description: testCategory.description + "test",
 			}
 			fetchMock.mockOnce(JSON.stringify(newCategory))
 			const returned = await wrapper.categories.modify({
 				categoryId: testCategory.id,
-				shortdesc: newCategory.shortdesc,
-				longdesc: newCategory.longdesc,
+				name: newCategory.name,
+				description: newCategory.description,
 			})
 
 			expect(returned).toEqual(newCategory)
@@ -128,14 +128,14 @@ describe("Categories", () => {
 
 			const newCategory = {
 				id: testCategory.id,
-				shortdesc: testCategory.shortdesc + "test",
-				longdesc: testCategory.longdesc + "test",
+				name: testCategory.name + "test",
+				description: testCategory.description + "test",
 			}
 			fetchMock.mockOnce(JSON.stringify(newCategory))
 			const returned = await wrapper.categories.modify({
 				categoryId: testCategory.id,
-				shortdesc: newCategory.shortdesc,
-				longdesc: newCategory.longdesc,
+				name: newCategory.name,
+				description: newCategory.description,
 			})
 
 			expect(returned).not.toBeNull()
@@ -159,8 +159,8 @@ describe("Categories", () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
 			await expect(wrapper.categories.modify({
 				categoryId: testCategory.id,
-				shortdesc: testCategory.shortdesc,
-				longdesc: testCategory.longdesc,
+				name: testCategory.name,
+				description: testCategory.description,
 			})).rejects.toThrow()
 		})
 	})

--- a/test/communities.spec.ts
+++ b/test/communities.spec.ts
@@ -36,7 +36,7 @@ describe("Communities", () => {
 
 			communities.map((community) => {
 				// the different communities should be cached properly too
-				const resolved = wrapper.communities.resolveID(community.id)
+				const resolved = wrapper.communities.resolveId(community.id)
 				expect(resolved).toEqual(community)
 			})
 		})
@@ -64,7 +64,7 @@ describe("Communities", () => {
 			})
 
 			expect(wrapper.communities.cache.size).toEqual(1) // the amount of cached communities should be only this added one
-			expect(resolvedConfig).toEqual(wrapper.communities.resolveID(testCommunity.id))
+			expect(resolvedConfig).toEqual(wrapper.communities.resolveId(testCommunity.id))
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
@@ -94,7 +94,7 @@ describe("Communities", () => {
 			})
 
 			expect(wrapper.communities.cache.size).toEqual(1) // the amount of cached communities should be only this added one
-			expect(wrapper.communities.resolveID(testCommunity.id)).toEqual(testCommunity)
+			expect(wrapper.communities.resolveId(testCommunity.id)).toEqual(testCommunity)
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
@@ -124,7 +124,7 @@ describe("Communities", () => {
 			})
 
 			expect(wrapper.communities.cache.size).toEqual(1) // the amount of cached communities should be only this added one
-			expect(wrapper.communities.resolveID(testCommunity.id)).toEqual(testCommunity)
+			expect(wrapper.communities.resolveId(testCommunity.id)).toEqual(testCommunity)
 		})
 		it("Fetching cache should work with communities returned", async () => {
 			const testCommunity = testCommunities[0]
@@ -168,7 +168,7 @@ describe("Communities", () => {
 			await wrapper.communities.fetchOwnCommunity({})
 
 			expect(wrapper.communities.cache.size).toEqual(1) // the amount of cached communities should be only this added one
-			expect(wrapper.communities.resolveID(testCommunity.id)).toEqual(testCommunity)
+			expect(wrapper.communities.resolveId(testCommunity.id)).toEqual(testCommunity)
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
@@ -240,7 +240,7 @@ describe("Communities", () => {
 			await wrapper.communities.create(testCommunity)
 
 			expect(wrapper.communities.cache.size).toEqual(1) // the amount of cached communities should be only this added one
-			expect(wrapper.communities.resolveID(testCommunity.id)).toEqual(testCommunity)
+			expect(wrapper.communities.resolveId(testCommunity.id)).toEqual(testCommunity)
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))
@@ -348,9 +348,9 @@ describe("Communities", () => {
 			expect(result).toEqual(testOne)
 
 			// the receiving community should still be in the cache
-			expect(wrapper.communities.resolveID(testOne.id)).toEqual(testOne)
+			expect(wrapper.communities.resolveId(testOne.id)).toEqual(testOne)
 			// the dissolved community should not be in the cache anymore
-			expect(wrapper.communities.resolveID(testTwo.id)).toBeNull()
+			expect(wrapper.communities.resolveId(testTwo.id)).toBeNull()
 		})
 		it("Should throw an error if an incorrect response is given from the API", async () => {
 			fetchMock.mockOnce(JSON.stringify({ hi: "true" }))

--- a/test/communities.spec.ts
+++ b/test/communities.spec.ts
@@ -224,18 +224,18 @@ describe("Communities", () => {
 			const apikey = faker.internet.password()
 			fetchMock.mockOnce(JSON.stringify({
 				community: testCommunity,
-				apiKey: apikey
+				apikey: apikey
 			}))
 			const resolvedCommunity = await wrapper.communities.create(testCommunity)
 
 			expect(resolvedCommunity.community).toEqual(testCommunity)
-			expect(resolvedCommunity.apiKey).toEqual(apikey)
+			expect(resolvedCommunity.apikey).toEqual(apikey)
 		})
 		it("Should be able to cache the created community", async () => {
 			const testCommunity = testCommunities[0]
 			fetchMock.mockOnce(JSON.stringify({
 				community: testCommunity,
-				apiKey: faker.internet.password()
+				apikey: faker.internet.password()
 			}))
 			await wrapper.communities.create(testCommunity)
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -4,8 +4,8 @@ import faker from "faker"
 export const createCategory = (): Category => {
 	return {
 		id: faker.datatype.uuid(),
-		shortdesc: faker.random.word(),
-		longdesc: faker.random.words(),
+		name: faker.random.word(),
+		description: faker.random.words(),
 	}
 }
 export const createCommunity = (): Community => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -29,6 +29,6 @@ export const createGuildConfig = (): GuildConfig => {
 			reports: faker.datatype.string(),
 			setConfig: faker.datatype.string(),
 		},
-		apiKey: faker.datatype.boolean() ? faker.internet.password() : null,
+		apikey: faker.datatype.boolean() ? faker.internet.password() : null,
 	}
 }


### PR DESCRIPTION
Update to API wrapper to support the backend refactor in FactorioAntigrief/fagc-backend#330. These are mostly backwards compatible, with the exception of the field renames.